### PR TITLE
Tests für "Neu"-Flag hinzugefügt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Tests ausführen
         run: npm run test-with-coverage
 
+      - name: Prüfen auf Änderungen an Dateien
+        run: |
+          git status --short
+          git add -A
+          git diff --cached --exit-code
+
       - name: Code formatieren
         if: >-
           ${{

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "generate-readme": "ts-node src/runners/generateReadme.runner.ts",
     "format-all": "prettier -w src/.",
-    "clear-new-flags": "ts-node src/clearNewProjectFlags.ts",
+    "clear-new-flags": "ts-node src/runners/clearNewProjectFlags.runner.ts",
     "check-translations": "i18n-check -s en --locales src/data/locales -f i18next",
     "test": "vitest",
     "test-with-coverage": "vitest run --coverage"

--- a/src/clearNewProjectFlags-ist.helper.ts
+++ b/src/clearNewProjectFlags-ist.helper.ts
@@ -19,7 +19,7 @@ export const plannedProjects: TypesPlannedProject[] = [
     emoji: ":)",
     state: ProjectStates.ACTIVE,
     newFlag: {
-      since: "2000-10-01",
+      since: "2025-09-01",
       newDescription: "Dieses Flag soll entfernt werden",
     },
   },
@@ -28,5 +28,15 @@ export const plannedProjects: TypesPlannedProject[] = [
     description: "Dieses Projekt soll unverändert bleiben",
     emoji: ":)",
     state: ProjectStates.WIP,
+  },
+  {
+    name: "Neues Flag",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: {
+      since: "2025-10-01",
+      newDescription: "Dieses Flag soll nicht entfernt werden",
+    },
   },
 ];

--- a/src/clearNewProjectFlags-ist.helper.ts
+++ b/src/clearNewProjectFlags-ist.helper.ts
@@ -1,0 +1,32 @@
+import { ProjectStates } from "./enums/projectStates";
+import { TypesPlannedProject } from "./types/typesPlannedProject";
+
+/**
+ * Diese Datei wird ausschließlich im Test genutzt, um die erfolgreiche
+ * Funktionsweise von ts-morph sicherzustellen.
+ */
+export const plannedProjects: TypesPlannedProject[] = [
+  {
+    name: "Flag auf False",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: false,
+  },
+  {
+    name: "Altes Flag",
+    description: "Dieses Projekt soll das Flag entfernen",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: {
+      since: "2000-10-01",
+      newDescription: "Dieses Flag soll entfernt werden",
+    },
+  },
+  {
+    name: "Kein Flag",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.WIP,
+  },
+];

--- a/src/clearNewProjectFlags-soll.helper.ts
+++ b/src/clearNewProjectFlags-soll.helper.ts
@@ -26,4 +26,14 @@ export const plannedProjects: TypesPlannedProject[] = [
     emoji: ":)",
     state: ProjectStates.WIP,
   },
+  {
+    name: "Neues Flag",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: {
+      since: "2025-10-01",
+      newDescription: "Dieses Flag soll nicht entfernt werden",
+    },
+  },
 ];

--- a/src/clearNewProjectFlags-soll.helper.ts
+++ b/src/clearNewProjectFlags-soll.helper.ts
@@ -1,0 +1,29 @@
+import { ProjectStates } from "./enums/projectStates";
+import { TypesPlannedProject } from "./types/typesPlannedProject";
+
+/**
+ * Diese Datei wird ausschließlich im Test genutzt, um die erfolgreiche
+ * Funktionsweise von ts-morph sicherzustellen.
+ */
+export const plannedProjects: TypesPlannedProject[] = [
+  {
+    name: "Flag auf False",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: false,
+  },
+  {
+    name: "Altes Flag",
+    description: "Dieses Projekt soll das Flag entfernen",
+    emoji: ":)",
+    state: ProjectStates.ACTIVE,
+    newFlag: false,
+  },
+  {
+    name: "Kein Flag",
+    description: "Dieses Projekt soll unverändert bleiben",
+    emoji: ":)",
+    state: ProjectStates.WIP,
+  },
+];

--- a/src/clearNewProjectFlags.test.ts
+++ b/src/clearNewProjectFlags.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "fs";
+import * as tsMorph from "ts-morph";
+import { describe, expect, test, vi } from "vitest";
+import { clearNewProjectFlags } from "./clearNewProjectFlags";
+
+/**
+ * ACHTUNG, FEHLENDE IDEMPOTENZ!
+ * Dieser Test ist aktuell relativ wackelig.
+ *
+ * Zum einen ist er datumsabhängig, was kein großes Problem darstellt,
+ * aber nicht sonderlich sauber ist.
+ *
+ * Zum anderen manipuliert AST hier aber eine Datei.
+ * Da auch die korrekte Ausführung von AST und nicht nur gemockte Aufrufe
+ * getestet werden sollen, ist dies aber aktuell der beste Ansatz.
+ * Die Tests müssen sequenziell ausgeführt werden und sind nicht idempotent.
+ * Nach Ausführung der Tests müssen die Changes wieder zurückgesetzt werden.
+ */
+
+const CURRENT_FILE = "src/clearNewProjectFlags-ist.helper.ts";
+const TARGET_FILE = "src/clearNewProjectFlags-soll.helper.ts";
+
+describe('"Neues Projekt" Flags entfernen', () => {
+  vi.mock("ts-morph", async (original) => {
+    const actual = (await original()) as typeof tsMorph;
+    return {
+      ...actual,
+      Project: vi.fn().mockImplementation(() => {
+        const project = new actual.Project();
+        return {
+          ...project,
+          addSourceFileAtPath: vi.fn().mockImplementation((path: string) => {
+            return project.addSourceFileAtPath(CURRENT_FILE);
+          }),
+        };
+      }),
+    };
+  });
+
+  test.sequential(
+    "[VORBEDINGUNG] Ausgangszustand unterscheidet sich von SOLL-Zustand",
+    () => {
+      const currentFile = readFileSync(CURRENT_FILE, "utf-8");
+      const targetFile = readFileSync(TARGET_FILE, "utf-8");
+
+      expect(currentFile).not.toBe(targetFile);
+    },
+  );
+
+  test.sequential("Neues Projekt Flag wird entfernt", () => {
+    clearNewProjectFlags();
+
+    const currentFile = readFileSync(CURRENT_FILE, "utf-8");
+    const targetFile = readFileSync(TARGET_FILE, "utf-8");
+
+    expect(currentFile).toBe(targetFile);
+  });
+});

--- a/src/clearNewProjectFlags.ts
+++ b/src/clearNewProjectFlags.ts
@@ -62,5 +62,3 @@ export const clearNewProjectFlags = () => {
 
   file.saveSync();
 };
-
-clearNewProjectFlags();

--- a/src/clearNewProjectFlags.ts
+++ b/src/clearNewProjectFlags.ts
@@ -31,7 +31,7 @@ export const clearNewProjectFlags = () => {
       typedChild.getProperty("newFlag");
 
       const newFlag = typedChild.getProperty("newFlag");
-      if (newFlag !== undefined && newFlag.getText() !== "false") {
+      if (newFlag !== undefined && newFlag.getText() !== "newFlag: false") {
         const newFlagTyped = newFlag
           .asKindOrThrow(SyntaxKind.PropertyAssignment)
           .getInitializer()

--- a/src/runners/clearNewProjectFlags.runner.ts
+++ b/src/runners/clearNewProjectFlags.runner.ts
@@ -1,0 +1,3 @@
+import { clearNewProjectFlags } from "../clearNewProjectFlags";
+
+clearNewProjectFlags();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         "src/data/**",
         "src/enums/**",
         "src/types/**",
+        "**/*.helper.ts",
       ],
     },
   },


### PR DESCRIPTION
Dieser PR liefert die Tests für die AST-Veränderungen für veraltete "Neu"-Flags.

Die Commits beinhalten einen durch die Tests gefundenen Bugfix, einen nicht idempotenten Zwischenstand (zum Nachvollziehen des Entwicklungsprozesses), die tatsächliche Testimplementierung und eine Erweiterung der Test-Pipeline zum Sicherstellen, dass durch die Tests keine Änderungen an den Repo-Dateien entstehen.

Da die tatsächliche Funktionsweise von ts-morph mit getestet werden soll, wurde nicht auf Mocks gesetzt. Es wurden helper-Dateien ergänzt, in denen der Test tatsächliche Veränderungen durchführen kann.