### PR TITLE
🔧 Versionierung gelockert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@lingual/i18n-check": "0.8.11",
-        "@types/luxon": "3.7.1",
-        "@types/node": "22.18.7",
+        "@types/luxon": "^3.7.1",
+        "@types/node": "^22.18.10",
         "@vitest/coverage-v8": "3.2.4",
         "i18next": "25.6.0",
         "i18next-fs-backend": "2.6.0",
@@ -19,8 +19,8 @@
         "prettier": "3.6.2",
         "prettier-plugin-organize-imports": "4.3.0",
         "ts-morph": "27.0.0",
-        "ts-node": "10.9.2",
-        "tslib": "2.8.1",
+        "ts-node": "~10.9.2",
+        "tslib": "~2.8.1",
         "typescript": "5.9.3",
         "vitest": "3.2.4"
       }
@@ -1439,9 +1439,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.18.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.7.tgz",
-      "integrity": "sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==",
+      "version": "22.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
+      "integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@lingual/i18n-check": "0.8.11",
-    "@types/luxon": "3.7.1",
-    "@types/node": "22.18.7",
+    "@types/luxon": "^3.7.1",
+    "@types/node": "^22.18.10",
     "@vitest/coverage-v8": "3.2.4",
     "i18next": "25.6.0",
     "i18next-fs-backend": "2.6.0",
@@ -28,8 +28,8 @@
     "prettier": "3.6.2",
     "prettier-plugin-organize-imports": "4.3.0",
     "ts-morph": "27.0.0",
-    "ts-node": "10.9.2",
-    "tslib": "2.8.1",
+    "ts-node": "~10.9.2",
+    "tslib": "~2.8.1",
     "typescript": "5.9.3",
     "vitest": "3.2.4"
   }


### PR DESCRIPTION
- bei Typen ist nur Major relevant
- ts-node, typescript und tslib auf Major/Minor reduziert
- soll weniger relevante Renovate-PRs reduzieren
- senkt Wartungsaufwand